### PR TITLE
[Feature] Add character loader utility

### DIFF
--- a/docs/character_format.md
+++ b/docs/character_format.md
@@ -11,3 +11,14 @@ Each character is defined by a JSON file with the following fields:
 - `intro_prompt`: Starting line for story generation.
 
 See `src/characters/sample_character.json` for an example.
+
+## Loading Characters
+
+Use `load_character` from `src/utils/characters.py` to read a profile file::
+
+    from src.utils.characters import load_character
+
+    character = load_character("path/to/profile.json")
+
+The loader checks that all required fields exist and raises `ValueError` if the
+file is missing information or is not valid JSON.

--- a/src/utils/characters.py
+++ b/src/utils/characters.py
@@ -1,0 +1,49 @@
+"""Utilities for loading character profiles."""
+
+import json
+
+REQUIRED_FIELDS = {
+    "id",
+    "display_name",
+    "starting_sanity",
+    "spiral_triggers",
+    "recovery_anchors",
+    "tone",
+    "intro_prompt",
+}
+
+
+def load_character(path: str) -> dict:
+    """Load and validate a character JSON file.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSON file containing the character definition.
+
+    Returns
+    -------
+    dict
+        Dictionary representing the character profile.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        If required fields are missing or the JSON is malformed.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+    missing = REQUIRED_FIELDS - data.keys()
+    if missing:
+        missing_list=", ".join(sorted(missing))
+        raise ValueError(f"Character file {path} missing fields: {missing_list}")
+
+    return data

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import json
+import pytest
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+from src.utils.characters import load_character
+
+
+def test_load_character_success(tmp_path):
+    src_file = os.path.join(project_root, 'src', 'characters', 'sample_character.json')
+    data = load_character(src_file)
+    assert data['id'] == 'sample'
+
+
+def test_load_character_missing_field(tmp_path):
+    bad_file = tmp_path / 'bad.json'
+    bad_content = {
+        "id": "bad"
+        # missing other fields
+    }
+    bad_file.write_text(json.dumps(bad_content))
+    with pytest.raises(ValueError):
+        load_character(str(bad_file))
+
+
+def test_load_character_bad_json(tmp_path):
+    bad_file = tmp_path / 'corrupt.json'
+    bad_file.write_text('{')
+    with pytest.raises(ValueError):
+        load_character(str(bad_file))


### PR DESCRIPTION
## Summary
- add `load_character` helper for reading and validating character JSON files
- document character loading in `docs/character_format.md`
- add tests for character loader

## Testing
- `pip install -r requirements.txt` *(fails: Could not fetch packages)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed9f833e4832488437307c8c1da77