### PR TITLE
[Feature] Add OpenAI API key helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ AGENTS.md              # Instructions for the Codex agent
    ```
 5. Open `http://localhost:5000` in your browser to see the placeholder homepage. The `/chat` and `/spiral` routes will return simple JSON messages.
 
+## OpenAI API Key
+
+Some features require an OpenAI API key. Set the variable `OPENAI_API_KEY` in your environment before running the server:
+```bash
+export OPENAI_API_KEY=sk-your-key
+```
+If you prefer a `.env` file, install [python-dotenv](https://pypi.org/project/python-dotenv/) and create a file containing:
+```
+OPENAI_API_KEY=sk-your-key
+```
+Then call `dotenv.load_dotenv()` early in your application to load the variable.
+
 ## How to Add New Characters
 
 Place a JSON file in `localspiral/characters/` following the format described in `docs/character_format.md`. The example `sample_character.json` shows all required fields.

--- a/localspiral/config.py
+++ b/localspiral/config.py
@@ -1,0 +1,15 @@
+"""Configuration helpers for API access."""
+
+import os
+
+
+def get_openai_api_key() -> str:
+    """Return the OpenAI API key from the environment.
+
+    The key is read from the ``OPENAI_API_KEY`` environment variable.
+    If the variable is missing or empty, ``RuntimeError`` is raised.
+    """
+    key = os.getenv("OPENAI_API_KEY")
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    return key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from localspiral.config import get_openai_api_key
+
+
+def test_get_openai_api_key(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-test')
+    assert get_openai_api_key() == 'sk-test'
+
+
+def test_get_openai_api_key_missing(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    with pytest.raises(RuntimeError):
+        get_openai_api_key()


### PR DESCRIPTION
## Summary
- add `get_openai_api_key` helper to read from `OPENAI_API_KEY`
- document API key requirement in README
- test the new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685edf7aa49883248c05f2b9c824b83d