### PR TITLE
[Feature] Add optional OpenAI scoring

### DIFF
--- a/localspiral/config.py
+++ b/localspiral/config.py
@@ -1,0 +1,4 @@
+import os
+
+# API key for optional OpenAI integration
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")

--- a/localspiral/utils/scoring.py
+++ b/localspiral/utils/scoring.py
@@ -11,7 +11,14 @@ from __future__ import annotations
 
 from collections import Counter
 import math
-from typing import Counter as CounterType
+from typing import Iterable, Counter as CounterType
+
+try:  # optional dependency
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - openai may not be installed
+    openai = None
+
+from ..config import OPENAI_API_KEY
 
 
 def _embed(text: str) -> CounterType[str]:
@@ -19,18 +26,44 @@ def _embed(text: str) -> CounterType[str]:
     return Counter(text.lower().split())
 
 
-def _cosine_similarity(vec1: CounterType[str], vec2: CounterType[str]) -> float:
-    """Return cosine similarity between two sparse vectors."""
-    keys = set(vec1) | set(vec2)
-    dot_product = sum(vec1.get(k, 0) * vec2.get(k, 0) for k in keys)
-    norm1 = math.sqrt(sum(v * v for v in vec1.values()))
-    norm2 = math.sqrt(sum(v * v for v in vec2.values()))
+def _openai_embed(text: str) -> Iterable[float]:
+    """Return an embedding using the OpenAI API."""
+    if openai is None or not OPENAI_API_KEY:
+        raise RuntimeError("OpenAI support is not available")
+
+    try:
+        client = openai.OpenAI(api_key=OPENAI_API_KEY)
+        result = client.embeddings.create(
+            input=[text],
+            model="text-embedding-3-small",
+        )
+        return result.data[0].embedding
+    except AttributeError:  # fallback for legacy package
+        openai.api_key = OPENAI_API_KEY
+        result = openai.Embedding.create(input=[text], model="text-embedding-3-small")
+        return result["data"][0]["embedding"]
+
+
+def _cosine_similarity(vec1: Iterable[float] | CounterType[str], vec2: Iterable[float] | CounterType[str]) -> float:
+    """Return cosine similarity between dense or sparse vectors."""
+    if isinstance(vec1, (list, tuple)) and isinstance(vec2, (list, tuple)):
+        dot_product = sum(a * b for a, b in zip(vec1, vec2))
+        norm1 = math.sqrt(sum(a * a for a in vec1))
+        norm2 = math.sqrt(sum(b * b for b in vec2))
+        if norm1 == 0 or norm2 == 0:
+            return 0.0
+        return dot_product / (norm1 * norm2)
+
+    keys = set(vec1) | set(vec2)  # type: ignore[arg-type]
+    dot_product = sum(vec1.get(k, 0) * vec2.get(k, 0) for k in keys)  # type: ignore[index]
+    norm1 = math.sqrt(sum(v * v for v in vec1.values()))  # type: ignore[call-arg]
+    norm2 = math.sqrt(sum(v * v for v in vec2.values()))  # type: ignore[call-arg]
     if norm1 == 0 or norm2 == 0:
         return 0.0
     return dot_product / (norm1 * norm2)
 
 
-def calculate_drift(reference: str, response: str) -> float:
+def calculate_drift(reference: str, response: str, *, use_openai: bool = False) -> float:
     """Return a drift score between two text fragments.
 
     The score ranges from ``0`` (identical) to ``1`` (completely dissimilar)
@@ -39,7 +72,11 @@ def calculate_drift(reference: str, response: str) -> float:
     if not reference or not response:
         return 1.0
 
-    ref_vec = _embed(reference)
-    resp_vec = _embed(response)
+    if use_openai:
+        ref_vec = list(_openai_embed(reference))
+        resp_vec = list(_openai_embed(response))
+    else:
+        ref_vec = _embed(reference)
+        resp_vec = _embed(response)
     similarity = _cosine_similarity(ref_vec, resp_vec)
     return 1.0 - similarity

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+from localspiral.utils import scoring
 from localspiral.utils.scoring import calculate_drift
 
 import pytest
@@ -16,3 +17,12 @@ def test_calculate_drift_different():
     score = calculate_drift('a b c', 'a b c d')
     assert 0 < score < 1
     assert score == pytest.approx(0.134, abs=1e-3)
+
+
+def test_calculate_drift_openai(monkeypatch):
+    def fake_embed(text):
+        return [1.0, 0.0] if "hello" in text else [0.0, 1.0]
+
+    monkeypatch.setattr(scoring, "_openai_embed", fake_embed)
+    score = calculate_drift("hello", "world", use_openai=True)
+    assert score == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add `config.py` to manage optional OpenAI API key
- support OpenAI embeddings in `calculate_drift`
- extend scoring tests with a mocked OpenAI path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edf81a06c832481a3dc42cd30e5e3