### PR TITLE
[Feature] Add deterministic map generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ AGENTS.md              # Instructions for the Codex agent
 
 Place a JSON file in `localspiral/characters/` following the format described in `docs/character_format.md`. The example `sample_character.json` shows all required fields.
 
+## Map Generation
+
+The `localspiral.utils` package includes a tiny map generator for experiments.
+Use `generate_map(seed)` to produce a deterministic grid of ``'.'`` and ``'#'``
+tiles. Calling the function with the same seed always returns the same layout.
+
+Example:
+
+```python
+from localspiral.utils.map import generate_map
+
+grid = generate_map(123)
+for row in grid:
+    print("".join(row))
+```
+
 ## Tests
 
 Run tests with:

--- a/localspiral/utils/map.py
+++ b/localspiral/utils/map.py
@@ -1,0 +1,21 @@
+"""Procedural generation for simple map layouts."""
+
+from __future__ import annotations
+
+import random
+
+
+def generate_map(seed: int) -> list[list[str]]:
+    """Return a deterministic 10x10 grid of tiles.
+
+    Each tile is either ``'.'`` representing open ground or ``'#'`` for a wall.
+    The layout is determined by the provided ``seed`` so that calling the
+    function with the same seed always yields the same map.
+    """
+    rng = random.Random(seed)
+    width = height = 10
+    grid: list[list[str]] = []
+    for _ in range(height):
+        row = ['#' if rng.random() < 0.2 else '.' for _ in range(width)]
+        grid.append(row)
+    return grid

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+from localspiral.utils.map import generate_map
+
+
+def test_generate_map_deterministic():
+    map_a = generate_map(42)
+    map_b = generate_map(42)
+    assert map_a == map_b
+
+
+def test_generate_map_different_seed():
+    map_a = generate_map(1)
+    map_b = generate_map(2)
+    assert map_a != map_b


### PR DESCRIPTION
## Summary
- add `generate_map` utility for deterministic 10x10 grids
- test map generation for deterministic output
- document map generator with example usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edf7dd4688324b7d58e49f10bd936