### PR TITLE
[Fix] Add run method to Flask stub

### DIFF
--- a/tests/stubs/flask/__init__.py
+++ b/tests/stubs/flask/__init__.py
@@ -58,6 +58,10 @@ class Flask:
 
         return _Client()
 
+    def run(self, debug: bool = False) -> None:
+        """Mimic ``Flask.run`` without starting a server."""
+        print(f"Stub Flask app running (debug={debug})")
+
 
 def jsonify(data: Any) -> Any:
     return data


### PR DESCRIPTION
## Summary
- extend Flask test stub with `run` method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee36b3298832496c4f37da18b3136