### PR TITLE
[Feature] Add dialogue module and dynamic chat

### DIFF
--- a/localspiral/routes/chat/__init__.py
+++ b/localspiral/routes/chat/__init__.py
@@ -1,8 +1,19 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
+
+from ...utils.dialogue import generate_reply
 
 chat_bp = Blueprint('chat', __name__)
 
 @chat_bp.route('/chat', methods=['GET'])
 def chat_example():
-    """Placeholder chat endpoint."""
-    return jsonify({'message': 'Chat endpoint reached.'})
+    """Return a dynamic response from the OpenAI API."""
+    prompt = request.args.get('prompt')
+    if not prompt:
+        return jsonify({'message': 'No prompt provided.'})
+
+    try:
+        reply = generate_reply(prompt)
+    except RuntimeError as exc:
+        return jsonify({'error': str(exc)})
+
+    return jsonify({'message': reply})

--- a/localspiral/utils/dialogue.py
+++ b/localspiral/utils/dialogue.py
@@ -1,0 +1,41 @@
+"""Simple wrapper around the OpenAI chat completion API."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib import request, error
+
+from ..config import get_openai_api_key
+
+
+_API_URL = "https://api.openai.com/v1/chat/completions"
+
+
+def _post_json(url: str, payload: dict[str, Any], headers: dict[str, str]) -> str:
+    """Send JSON data via POST and return the response body as a string."""
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(url, data=data, headers=headers, method="POST")
+    with request.urlopen(req) as resp:
+        return resp.read().decode("utf-8")
+
+
+def generate_reply(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+    """Return the assistant reply for ``prompt`` using OpenAI's API."""
+    api_key = get_openai_api_key()
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    try:
+        body = _post_json(_API_URL, payload, headers)
+    except error.HTTPError as exc:
+        raise RuntimeError(f"OpenAI API request failed: {exc}") from exc
+
+    data: Any = json.loads(body)
+    return data["choices"][0]["message"]["content"]

--- a/tests/stubs/flask/__init__.py
+++ b/tests/stubs/flask/__init__.py
@@ -1,5 +1,14 @@
 """Minimal Flask stub for tests."""
 from typing import Callable, Dict, Any
+from urllib.parse import parse_qs, urlparse
+
+
+class _Request:
+    def __init__(self) -> None:
+        self.args: Dict[str, Any] = {}
+
+
+request = _Request()
 
 
 class Response:
@@ -48,9 +57,12 @@ class Flask:
 
         class _Client:
             def get(self, path: str) -> Response:
-                view = app.routes.get(path)
+                parsed = urlparse(path)
+                view = app.routes.get(parsed.path)
                 if view is None:
                     return Response(None, 404)
+                args = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+                request.args = args
                 result = view()
                 if isinstance(result, Response):
                     return result

--- a/tests/test_dialogue.py
+++ b/tests/test_dialogue.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import json
+
+stubs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stubs'))
+sys.path.insert(0, stubs_path)
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+sys.path.insert(0, os.path.join(project_root, 'localspiral'))
+
+import pytest
+
+from localspiral.utils import dialogue
+
+
+class DummyResponse:
+    def __init__(self, body: str):
+        self._body = body
+
+    def read(self):
+        return self._body.encode('utf-8')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_generate_reply(monkeypatch):
+    payload = {"choices": [{"message": {"content": "hi"}}]}
+
+    def fake_urlopen(req):
+        body = json.dumps(payload)
+        return DummyResponse(body)
+
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk-test')
+    monkeypatch.setattr(dialogue, 'request', dialogue.request)
+    monkeypatch.setattr(dialogue.request, 'urlopen', fake_urlopen)
+    result = dialogue.generate_reply('hello')
+    assert result == 'hi'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(project_root, 'localspiral'))
 
 import pytest
 from localspiral.main import create_app
+from localspiral.utils import dialogue
 
 
 @pytest.fixture
@@ -22,12 +23,12 @@ def client(app):
     return app.test_client()
 
 
-def test_chat_endpoint(client):
-    response = client.get('/chat')
+def test_chat_endpoint(client, monkeypatch):
+    monkeypatch.setattr('localspiral.routes.chat.generate_reply', lambda prompt: 'ok')
+    response = client.get('/chat?prompt=hello')
     assert response.status_code == 200
     data = response.get_json()
-    assert isinstance(data, dict)
-    assert 'message' in data
+    assert data['message'] == 'ok'
 
 
 def test_spiral_endpoint(client):


### PR DESCRIPTION
## Summary
- add `dialogue.generate_reply` for OpenAI API calls
- use new helper in `/chat` route
- mock OpenAI calls in unit tests
- support query parsing in Flask stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee85654c88324835613528de88797