### PR TITLE
[Feature] Add map route

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ localspiral/
    ```bash
    localspiral
    ```
-5. Open `http://localhost:5000` in your browser to see the placeholder homepage. The `/chat` and `/spiral` routes will return simple JSON messages.
+5. Open `http://localhost:5000` in your browser to see the placeholder homepage. The `/chat`, `/spiral`, and `/map` routes will return simple JSON messages.
 
 ## OpenAI API Key
 

--- a/localspiral/main.py
+++ b/localspiral/main.py
@@ -2,12 +2,14 @@
 from flask import Flask, render_template
 from .routes.chat import chat_bp
 from .routes.spiral import spiral_bp
+from .routes.map import map_bp
 
 
 def create_app() -> Flask:
     app = Flask(__name__, template_folder='templates')
     app.register_blueprint(chat_bp)
     app.register_blueprint(spiral_bp)
+    app.register_blueprint(map_bp)
 
     @app.route('/')
     def index():

--- a/localspiral/routes/map/__init__.py
+++ b/localspiral/routes/map/__init__.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, jsonify, request
+
+from ...utils.map import generate_map
+
+map_bp = Blueprint('map', __name__)
+
+
+@map_bp.route('/map', methods=['GET'])
+def get_map():
+    """Return a procedurally generated map as JSON."""
+    seed_str = request.args.get('seed', '0')
+    try:
+        seed = int(seed_str)
+    except ValueError:
+        seed = 0
+    grid = generate_map(seed)
+    return jsonify({'grid': grid})

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,3 +37,11 @@ def test_spiral_endpoint(client):
     data = response.get_json()
     assert isinstance(data, dict)
     assert 'message' in data
+
+
+def test_map_endpoint(client):
+    first = client.get('/map?seed=5')
+    second = client.get('/map?seed=5')
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.get_json()['grid'] == second.get_json()['grid']


### PR DESCRIPTION
## Summary
- expose `generate_map` via new `/map` API endpoint
- register the new blueprint in `create_app`
- document the `/map` route in the README
- test that `/map` returns deterministic maps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee95efbe88324acd5966137c3a7d4