### PR TITLE
[Feature] Add PyInstaller build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,30 @@ pytest
 ```
 They cover basic utility functions and ensure the project imports correctly.
 
+## Building a Standalone Binary
+
+You can package the project into a single executable using
+[PyInstaller](https://pyinstaller.org/). This is handy if you want to
+distribute the server without requiring Python to be installed.
+
+1. Activate your virtual environment (see **Getting Started**).
+2. Install PyInstaller if you do not already have it:
+   ```bash
+   pip install pyinstaller
+   ```
+3. Run the build script:
+   ```bash
+   ./scripts/build_exe.sh
+   ```
+   The command produces a binary in the `dist/` directory.
+4. Start the packaged server:
+   ```bash
+   ./dist/localspiral
+   ```
+
+The executable uses the same `localspiral` entry point as the regular
+`pip` installation, providing an easy install-to-run experience.
+
 ## Why `.gitignore`?
 
 The `.gitignore` file prevents temporary or local files (like virtual environments and compiled Python bytecode) from cluttering your repository. This keeps version control clean and focused on source code.

--- a/localspiral/__main__.py
+++ b/localspiral/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_exe.sh
+++ b/scripts/build_exe.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Build a standalone localspiral binary using PyInstaller.
+set -e
+PYINSTALLER=$(python - <<'PY'
+try:
+    import PyInstaller  # noqa: F401
+    print('ok')
+except ImportError:
+    print('missing')
+PY)
+if [ "$PYINSTALLER" = "missing" ]; then
+    echo "PyInstaller not found. Installing..."
+    pip install pyinstaller
+fi
+pyinstaller --onefile -n localspiral -m localspiral
+


### PR DESCRIPTION
## Summary
- expose package entry via `localspiral.__main__`
- add a simple PyInstaller build script
- document how to build a standalone binary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eead5a3f08324bd572fb1ad50391b