### PR TITLE
[Refactor] Centralize test path setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+# Add the stubs directory so tests use the bundled Flask stub.
+stubs_path = os.path.join(os.path.dirname(__file__), 'stubs')
+if stubs_path not in sys.path:
+    sys.path.insert(0, stubs_path)
+
+# Add the project root to ensure ``localspiral`` imports resolve without
+# installing the package.
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -1,19 +1,14 @@
 import os
-import sys
 import json
 import pytest
 
-stubs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stubs'))
-sys.path.insert(0, stubs_path)
-
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, project_root)
-
 from localspiral.utils.characters import load_character
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 
 def test_load_character_success(tmp_path):
-    src_file = os.path.join(project_root, 'localspiral', 'characters', 'sample_character.json')
+    src_file = os.path.join(PROJECT_ROOT, 'localspiral', 'characters', 'sample_character.json')
     data = load_character(src_file)
     assert data['id'] == 'sample'
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,4 @@
 import os
-import sys
-
-stubs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stubs'))
-sys.path.insert(0, stubs_path)
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import pytest
 from localspiral.config import get_openai_api_key

--- a/tests/test_dialogue.py
+++ b/tests/test_dialogue.py
@@ -1,12 +1,5 @@
 import os
-import sys
 import json
-
-stubs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stubs'))
-sys.path.insert(0, stubs_path)
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, project_root)
-sys.path.insert(0, os.path.join(project_root, 'localspiral'))
 
 import pytest
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,11 +1,4 @@
 import os
-import sys
-
-stubs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stubs'))
-sys.path.insert(0, stubs_path)
-
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, project_root)
 
 from localspiral.utils.map import generate_map
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,13 +1,3 @@
-import os
-import sys
-
-stubs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stubs'))
-sys.path.insert(0, stubs_path)
-
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, project_root)
-sys.path.insert(0, os.path.join(project_root, 'localspiral'))
-
 import pytest
 from localspiral.main import create_app
 from localspiral.utils import dialogue

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,11 +1,3 @@
-import os
-import sys
-
-stubs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stubs'))
-sys.path.insert(0, stubs_path)
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from localspiral.utils.scoring import calculate_drift
 
 import pytest


### PR DESCRIPTION
## Summary
- ensure tests use a shared `conftest.py` for path adjustments
- clean up duplicated `sys.path` logic in test modules
- verify the Flask app can be exercised with the stub framework

## Testing
- `pytest -q`
- `PYTHONPATH=tests/stubs python - <<'EOF'
from localspiral.main import create_app
app = create_app()
client = app.test_client()
print('spiral', client.get('/spiral').get_json())
print('map first row', client.get('/map?seed=1').get_json()['grid'][0])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685eecfd89688324a69aefa882448f00