### PR TITLE
[Feature] Add helper script and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ localspiral/
    ```bash
    pip install -e .
    ```
-4. **Run the server**:
+4. **Run the included helper script**:
    ```bash
-   localspiral
+   ./scripts/run_all.sh
    ```
 5. Open `http://localhost:5000` in your browser to see the placeholder homepage. The `/chat`, `/spiral`, and `/map` routes will return simple JSON messages.
 

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+pytest
+localspiral


### PR DESCRIPTION
## Summary
- add `scripts/run_all.sh` to run tests and launch the server
- document usage of this script in the Getting Started guide

## Testing
- `pytest`
- `./scripts/run_all.sh` *(fails: `localspiral` command not found)*
- `pip install -e .` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_685efab9a8c48324b7a4f071107427fe