### PR TITLE
[Refactor] Improve project structure and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ localspiral/
 │   ├── utils/             # Scoring modules and helpers
 │   └── main.py            # Entry point for the Flask server
 ├── tests/                 # Unit tests
+├── scripts/               # Helper scripts
 ├── .gitignore
 ├── LICENSE
 ├── README.md              # This file
 ├── AGENTS.md              # Instructions for the Codex agent
-└── requirements.txt       # Dependencies
+├── requirements.txt       # Dependencies
+└── pyproject.toml         # Package configuration
 ```
 ## Getting Started
 
@@ -37,9 +39,13 @@ localspiral/
    pip install -e .
    ```
 4. **Run the included helper script**:
-   ```bash
-   ./scripts/run_all.sh
-   ```
+```bash
+./scripts/run_all.sh
+```
+   Or on Windows:
+```bat
+scripts\run.bat
+```
 5. Open `http://localhost:5000` in your browser to see the placeholder homepage. The `/chat`, `/spiral`, and `/map` routes will return simple JSON messages.
 
 ## OpenAI API Key
@@ -48,11 +54,15 @@ Some features require an OpenAI API key. Set the variable `OPENAI_API_KEY` in yo
 ```bash
 export OPENAI_API_KEY=sk-your-key
 ```
-If you prefer a `.env` file, install [python-dotenv](https://pypi.org/project/python-dotenv/) and create a file containing:
+On Windows PowerShell use:
+```powershell
+$env:OPENAI_API_KEY="sk-your-key"
+```
+You can also create a `.env` file with [python-dotenv](https://pypi.org/project/python-dotenv/). The application loads this file automatically.
+Create a file named `.env` containing:
 ```
 OPENAI_API_KEY=sk-your-key
 ```
-Then call `dotenv.load_dotenv()` early in your application to load the variable.
 
 ## How to Add New Characters
 

--- a/localspiral/config.py
+++ b/localspiral/config.py
@@ -2,6 +2,14 @@
 
 import os
 
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+if load_dotenv:
+    load_dotenv()
+
 
 def get_openai_api_key() -> str:
     """Return the OpenAI API key from the environment.

--- a/localspiral/routes/chat/__init__.py
+++ b/localspiral/routes/chat/__init__.py
@@ -2,6 +2,10 @@ from flask import Blueprint, jsonify, request
 
 from ...utils.dialogue import generate_reply
 
+SYSTEM_PROMPT = (
+    "You are Tyler Scienceman, a helpful scientist with a stoic tone."
+)
+
 chat_bp = Blueprint('chat', __name__)
 
 @chat_bp.route('/chat', methods=['GET'])
@@ -12,7 +16,7 @@ def chat_example():
         return jsonify({'message': 'No prompt provided.'})
 
     try:
-        reply = generate_reply(prompt)
+        reply = generate_reply(prompt, system_prompt=SYSTEM_PROMPT)
     except RuntimeError as exc:
         return jsonify({'error': str(exc)})
 

--- a/localspiral/utils/dialogue.py
+++ b/localspiral/utils/dialogue.py
@@ -20,16 +20,30 @@ def _post_json(url: str, payload: dict[str, Any], headers: dict[str, str]) -> st
         return resp.read().decode("utf-8")
 
 
-def generate_reply(prompt: str, model: str = "gpt-3.5-turbo") -> str:
-    """Return the assistant reply for ``prompt`` using OpenAI's API."""
+def generate_reply(prompt: str, model: str = "gpt-3.5-turbo", *, system_prompt: str | None = None) -> str:
+    """Return the assistant reply for ``prompt`` using OpenAI's API.
+
+    Parameters
+    ----------
+    prompt:
+        The user's message.
+    model:
+        The OpenAI chat model to use.
+    system_prompt:
+        Optional system prompt that will be prepended to the conversation.
+    """
     api_key = get_openai_api_key()
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}",
     }
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": prompt})
     payload = {
         "model": model,
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": messages,
     }
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [{name = "AI Spiral"}]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "Flask==3.0.0"
+    "Flask==3.0.0",
+    "python-dotenv==1.0.0"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.0
 pytest==7.4.0
+python-dotenv==1.0.0

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -1,0 +1,10 @@
+@echo off
+REM Simple helper to start the AI Spiral Simulator on Windows
+
+REM Load environment variables from .env if present
+if exist ..\.env (
+    for /f "usebackq delims=" %%A in ("..\.env") do set %%A
+)
+
+python -m localspiral.main
+

--- a/tests/test_dialogue.py
+++ b/tests/test_dialogue.py
@@ -30,5 +30,5 @@ def test_generate_reply(monkeypatch):
     monkeypatch.setenv('OPENAI_API_KEY', 'sk-test')
     monkeypatch.setattr(dialogue, 'request', dialogue.request)
     monkeypatch.setattr(dialogue.request, 'urlopen', fake_urlopen)
-    result = dialogue.generate_reply('hello')
+    result = dialogue.generate_reply('hello', system_prompt='test')
     assert result == 'hi'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -14,7 +14,10 @@ def client(app):
 
 
 def test_chat_endpoint(client, monkeypatch):
-    monkeypatch.setattr('localspiral.routes.chat.generate_reply', lambda prompt: 'ok')
+    monkeypatch.setattr(
+        'localspiral.routes.chat.generate_reply',
+        lambda prompt, system_prompt=None: 'ok'
+    )
     response = client.get('/chat?prompt=hello')
     assert response.status_code == 200
     data = response.get_json()


### PR DESCRIPTION
## Summary
- add python-dotenv support and optional loading in `config.py`
- enhance `/chat` route with Tyler Scienceman system prompt
- allow `generate_reply` to accept a system prompt
- document Windows setup, `.env` usage and helper scripts
- include `run.bat` for Windows
- update dependencies and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed741430883249de6647fc599a072